### PR TITLE
issue-106-mouse-functionality -- shooting with mouse

### DIFF
--- a/finalfate/gameInput.js
+++ b/finalfate/gameInput.js
@@ -36,6 +36,8 @@ function initAllInput() {
         window.addEventListener("keyup", getKeyRelease);
         //Mouse movement catching.
         window.addEventListener("mousemove", getMouseMovement);
+        window.addEventListener("mousedown", getMouseDown);
+        window.addEventListener("mouseup", getMouseUp);
     }
     if (gamepad_handle !== null) {
         //Terminate polling of specific (?) gamepad.
@@ -123,6 +125,21 @@ function getKeyPress(event) {
         } else if (event.keyCode === 80) {
             pause = 5;
         }
+    }
+}
+
+function getMouseDown(event) {
+    if (typeof event === 'object') {
+    //keycode 0 -> most browsers
+    //keycode 1 -> internet explorer left click -> middle mouse on other browsers
+      switch (event.button) {
+        case 0:
+          shoot = 5;
+          break;
+        case 1:
+          shoot = 5;
+          break;
+      }
     }
 }
 
@@ -245,6 +262,21 @@ function getKeyRelease(event) {
         }
     }
 
+}
+
+function getMouseUp(event) {
+    if (typeof event === 'object') {
+    //keycode 0 -> most browsers
+    //keycode 1 -> internet explorer left click -> middle mouse on other browsers
+      switch (event.button) {
+        case 0:
+          shoot = 0;
+          break;
+        case 1:
+          shoot = 0;
+          break;
+      }
+    }
 }
 
 /**

--- a/finalfate/main.js
+++ b/finalfate/main.js
@@ -55,8 +55,6 @@ initAllInput();
 window.addEventListener("resize", sizeChanged);
 //Invalidate keyboard input when window focus is lost.
 window.addEventListener("blur",focusLost);
-//window.canvas.width = 800;
-//window.canvas.height = 600;
 
 
 
@@ -749,10 +747,6 @@ function background1_render() {
     context.fillRect(this.middleX, this.middleY - 150, 800, 180);
     context.fillStyle = "#0000FF";
     context.fillRect(this.middleX, this.middleY, 800, 600);
-
-    //Spaceship moving bounds -- remove this at deployment
-    context.fillStyle = "#000089";
-    context.fillRect(20, 280, 760, 260);
 }
 
 //Level 2 - The Solar System rendering function


### PR DESCRIPTION
As proposed on #106 finished mouse functionality with adding mouse shooting with left or middle click to work on different browsers.

Tested on Microsoft Edge and Google Chrome.
-Remove the rect to visualize the bounds of the spaceship in order to test how the spacehip responds to movements outside of the allowed bounds.
-Remove left over commented lines in main.js regarding window size
-Added an eventListener for mouseDown and mouseUp
--Implemented the mouseDown and up listener, that mimics behaviour of space bar, when left click or middle click is pressed. The player can only shoot once (can't hold to shoot) that's intented behaviour.